### PR TITLE
Fix slow build by chefignoring all build files

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/). Note that
 
 ## Unreleased
 
+* Fix exclusion of build-time files from vendored cookbook
+
 ## 0.4.0 (2017-08-09)
 
 * Exclude build-time code from generated cookbook (in the hope this may improve

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/). Note that
 
 ## Unreleased
 
+## 0.4.1 (2017-08-10)
+
 * Fix exclusion of build-time files from vendored cookbook
 
 ## 0.4.0 (2017-08-09)

--- a/chefignore
+++ b/chefignore
@@ -1,6 +1,16 @@
 # Don't include version control, specs or build-time dependencies in the cookbook
+# Note that per https://github.com/berkshelf/berkshelf/issues/1492 berkshelf does
+# not treat directory-patterns with /* in the same way as chef itself, so we need
+# to specify an explicit directory name for each of the directories we want to
+# exclude. Otherwise per https://github.com/chefspec/chefspec/issues/870 the
+# chefspec run is painfully slow due to all the extra cookbook content.
 .git
 .git/*
+gemfiles
+gemfiles/*
+spec
 spec/*
+test
 test/*
+vendor
 vendor/*

--- a/metadata.rb
+++ b/metadata.rb
@@ -7,7 +7,7 @@ description 'Standard mySQL installation for our applications, including relevan
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 issues_url 'https://github.com/ingenerator/chef-ingenerator-mysql/issues'
 source_url 'https://github.com/ingenerator/chef-ingenerator-mysql'
-version '0.4.0'
+version '0.4.1'
 
 %w(ubuntu).each do |os|
   supports os


### PR DESCRIPTION
Berkshelf doesn't properly process the chefignore (berkshelf issue
1492) and this was causing chefspec to upload the cookbook with all
the vendor dependencies, making the build multiple minutes instead
of seconds.