### PR TITLE
Ensure mysql can read the config file

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,11 @@ This project adheres to [Semantic Versioning](http://semver.org/). Note that
 
 ## Unreleased
 
+* [BUG] mysql config files need to be world-readable. If not then mysql will silently IGNORE them and you will spend
+  ages trying to work out why the config settings aren't being applied. Worse, the pre-start command on ubuntu runs
+  as root so it can read them and will fail with an error if they have invalid values, but then the actual start command
+  runs as mysql so won't see them. FFS.
+
 ## 0.5.0 (2019-02-17)
 
 * [BREAKING] Ensure chef isn't trying to move the mysql data directory - leave it configured as /var/lib/mysql and

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/). Note that
 
 ## Unreleased
 
+## 0.5.1 (2019-02-25)
+
 * [BUG] mysql config files need to be world-readable. If not then mysql will silently IGNORE them and you will spend
   ages trying to work out why the config settings aren't being applied. Worse, the pre-start command on ubuntu runs
   as root so it can read them and will fail with an error if they have invalid values, but then the actual start command

--- a/metadata.rb
+++ b/metadata.rb
@@ -7,7 +7,7 @@ description 'Standard mySQL installation for our applications, including relevan
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 issues_url 'https://github.com/ingenerator/chef-ingenerator-mysql/issues'
 source_url 'https://github.com/ingenerator/chef-ingenerator-mysql'
-version '0.5.0'
+version '0.5.1'
 
 %w(ubuntu).each do |os|
   supports os

--- a/recipes/custom_config.rb
+++ b/recipes/custom_config.rb
@@ -62,7 +62,7 @@ end
 template "/etc/mysql/my.cnf" do
   owner 'root'
   group 'root'
-  mode  '0640'
+  mode  '0644'
   variables(
     bind_address:      node['mysql']['bind_address'],
     default_time_zone: node['mysql']['default-time-zone'],


### PR DESCRIPTION
Otherwise it will ignore *everything* in it without any complaint,
but still fail to start if you include an invalid config key,
and you'll scratch your head through to your opposite ear trying
to figure out why before you realise the validation runs as root
and can see it...